### PR TITLE
fix: move project validation

### DIFF
--- a/controllers/backendResourceController.js
+++ b/controllers/backendResourceController.js
@@ -1,10 +1,8 @@
 import BackendResource from "../models/backendResourceModel.js";
-import Project from "../models/projectModel.js";
 import * as factory from "./controllerFactory.js";
 
 export const createBackendResource = factory.createOne(
   BackendResource,
-  Project,
   "project",
   "projectId",
 );

--- a/controllers/controllerFactory.js
+++ b/controllers/controllerFactory.js
@@ -1,7 +1,7 @@
 import { catchAsyncErrors } from "../utils/helpers.js";
 import AppError from "../utils/appError.js";
 
-export const createOne = (Model, ParentModel, parentProperty, paramName) =>
+export const createOne = (Model, parentProperty, paramName) =>
   catchAsyncErrors(async (req, res, next) => {
     const { _id: id } = req.currentUser;
 
@@ -16,16 +16,6 @@ export const createOne = (Model, ParentModel, parentProperty, paramName) =>
     let parent = { user: id };
 
     if (parentProperty) {
-      const validParent = await ParentModel.findById(req.params[paramName]);
-
-      if (!validParent) {
-        return next(
-          new AppError(
-            "Cannot create this document without a valid parent ID.",
-          ),
-        );
-      }
-
       parent = { [parentProperty]: req.params[paramName] };
     }
 

--- a/controllers/pageController.js
+++ b/controllers/pageController.js
@@ -1,13 +1,7 @@
 import Page from "../models/pageModel.js";
-import Project from "../models/projectModel.js";
 import * as factory from "./controllerFactory.js";
 
-export const createPage = factory.createOne(
-  Page,
-  Project,
-  "project",
-  "projectId",
-);
+export const createPage = factory.createOne(Page, "project", "projectId");
 
 export const getPages = factory.getAll(Page, "project", "projectId");
 

--- a/controllers/userStoriesController.js
+++ b/controllers/userStoriesController.js
@@ -1,10 +1,8 @@
-import Project from "../models/projectModel.js";
 import UserStory from "../models/userStoriesModel.js";
 import * as factory from "./controllerFactory.js";
 
 export const createUserStory = factory.createOne(
   UserStory,
-  Project,
   "project",
   "projectId",
 );

--- a/models/backendResourceModel.js
+++ b/models/backendResourceModel.js
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import slugify from "slugify";
 import Project from "./projectModel.js";
+import * as factory from "./validatorFactory.js";
 
 const backendResourceSchema = mongoose.Schema({
   name: {
@@ -10,6 +11,11 @@ const backendResourceSchema = mongoose.Schema({
   project: {
     type: mongoose.Schema.ObjectId,
     ref: "Project",
+    validate: {
+      validator: id => factory.validReference(Project, id),
+      message: props =>
+        factory.validReferenceMessage("Backend Resource", props),
+    },
   },
 
   createdAt: {

--- a/models/pageModel.js
+++ b/models/pageModel.js
@@ -1,6 +1,7 @@
 import mongoose from "mongoose";
 import slugify from "slugify";
 import Project from "./projectModel.js";
+import * as factory from "./validatorFactory.js";
 
 const pageSchema = mongoose.Schema({
   name: {
@@ -18,6 +19,10 @@ const pageSchema = mongoose.Schema({
   project: {
     type: mongoose.Schema.ObjectId,
     ref: "Project",
+    validate: {
+      validator: id => factory.validReference(Project, id),
+      message: props => factory.validReferenceMessage("Page", props),
+    },
   },
 
   createdAt: {

--- a/models/projectModel.js
+++ b/models/projectModel.js
@@ -3,6 +3,7 @@ import mongoose from "mongoose";
 import slugify from "slugify";
 import User from "./userModel.js";
 import UserStory from "./userStoriesModel.js";
+import * as factory from "./validatorFactory.js";
 
 const projectSchema = new mongoose.Schema({
   name: {
@@ -13,6 +14,10 @@ const projectSchema = new mongoose.Schema({
   user: {
     type: mongoose.Schema.ObjectId,
     ref: "User",
+    validate: {
+      validator: id => factory.validReference(User, id),
+      message: props => factory.validReferenceMessage("Project", props),
+    },
   },
 
   userStories: {

--- a/models/userStoriesModel.js
+++ b/models/userStoriesModel.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/no-cycle */
 import mongoose from "mongoose";
 import Project from "./projectModel.js";
+import * as factory from "./validatorFactory.js";
 
 const userStorySchema = mongoose.Schema({
   story: {
@@ -25,6 +26,10 @@ const userStorySchema = mongoose.Schema({
     type: mongoose.Schema.ObjectId,
     ref: "Project",
     required: [true, "Your user story needs a project!"],
+    validate: {
+      validator: id => factory.validReference(Project, id),
+      message: props => factory.validReferenceMessage("User Story", props),
+    },
   },
 
   slug: {

--- a/models/validatorFactory.js
+++ b/models/validatorFactory.js
@@ -1,0 +1,9 @@
+export const validReference = async function (Model, id) {
+  return Boolean(await Model.findById(id));
+};
+
+// export const validReferenceMessage = props =>
+//   `"${props.path}" validation failed. It must be attached to a valid Project ID: ${props.value}`;
+
+export const validReferenceMessage = (docName, props) =>
+  `${docName} couldn't be created. It must be attached to a valid ${props.path.toUpperCase()} ID. This one didn't work: ${props.value}`;


### PR DESCRIPTION
# Moved Parent-Doc Validation Into Model

Moved all of the validation/error handling over to model and created a factory file to generate reusable validators.