### PR TITLE
feature: make techs independent addendum

### DIFF
--- a/controllers/projectController.js
+++ b/controllers/projectController.js
@@ -13,4 +13,4 @@ export const deleteProject = factory.deleteOne(models.Project);
 
 export const deleteProjects = factory.deleteAll(models.Project);
 
-export const addTech = factory.addReference(models.Project, "tech");
+export const updateTech = factory.updateReference(models.Project, "tech");

--- a/routers/projectRouter.js
+++ b/routers/projectRouter.js
@@ -18,6 +18,6 @@ router
   .patch(projectController.updateProject)
   .delete(projectController.deleteProject);
 
-router.route("/:projectId/:techId").patch(projectController.addTech);
+router.route("/:projectId/:techId").patch(projectController.updateTech);
 
 export default router;


### PR DESCRIPTION
# Fixed Issue With Last Commit

Techs can now be added and removed via ONE endpoint which takes the two ID's as parameters and an action query.